### PR TITLE
This commit fixes the following issue

### DIFF
--- a/lib/agenda.js
+++ b/lib/agenda.js
@@ -386,7 +386,7 @@ function processJobs(extraJob) {
         if (jobDefinition.concurrency > jobDefinition.running &&
             self._runningJobs.length < self._maxConcurrency) {
 
-          if(jobDefinition._lastCompletedJob){
+          if(jobDefinition._lastCompletedJob && !jobDefinition._lastCompletedJob.attrs.disabled){
             //If The Next Run Time At Is Less Than The Last Completed Jobs Next Run, Then Don't Run It Again.
             if(job.attrs.nextRunAt < jobDefinition._lastCompletedJob.attrs.nextRunAt){
               jobProcessing();


### PR DESCRIPTION
If:
1) A Job was scheduled
2) During the job execution its 'nextRunAt' time was set
3) The job ended and got disabled
4) If another job of the same type (same definition) was scheduled *BEFORE* the 'nextRunAt' of the previously run job, that job will never run.